### PR TITLE
Not the world's longest hackathon

### DIFF
--- a/components/meta.js
+++ b/components/meta.js
@@ -3,7 +3,7 @@ import Head from 'next/head'
 export default ({
   name = 'Hack Club',
   title = 'The Hacker Zephyr',
-  description = `Every summer Hack Club does something special. This year, we're chartering a train across America, and hosting the world's longest hackathon (in miles).`,
+  description = `Every summer Hack Club does something special. This year, we're chartering a train across America, and hosting the world's longest hackathon on land (in miles).`,
   image = 'https://slack-oauth-starter-test-xy120.hackclub.dev/meta.png'
 }) => (
   <Head>

--- a/components/telegram.js
+++ b/components/telegram.js
@@ -59,7 +59,7 @@ const Telegram = () => (
         to San Francisco. From there, we'll follow the Pacific Ocean and end in Los Angeles, where we'll finish at SpaceX.
       </p>
       <p>
-        Onboard, we're hosting the world's longest hackathon: 3,502 miles long.
+        Onboard, we're hosting the world's longest hackathon on land: 3,502 miles long.
       </p>
       <p>
         This won't be a regular hackathon. Imagine a travelling hacker festival, where the goal is to make beautiful and interesting things with code.


### PR DESCRIPTION
https://www.theverge.com/2013/3/21/4130716/british-airways-ungrounded-hackathon-on-a-plane

Sadly, Zephyr won't be the longest Hackathon: British Airways ran a Hackathon on a plane from SFO to LHR (5,351 mi).

Melody pointed this out [on Slack](https://hackclub.slack.com/archives/C023JP4JQEM/p1622501036394600)